### PR TITLE
6 bug event listener cannot be stopped due to blocking call   needs timeout support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "rustici"
-version = "1.0.1"
+version = "1.1.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "rustici"
-version = "1.0.0"
+version = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustici"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 authors = ["mira-mobility"]
 description = "Pure-Rust client for strongSwan's VICI protocol"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustici"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["mira-mobility"]
 description = "Pure-Rust client for strongSwan's VICI protocol"

--- a/src/client.rs
+++ b/src/client.rs
@@ -23,28 +23,128 @@ pub struct Client {
 }
 
 impl Client {
-    /// Connect to a VICI UNIX socket (e.g., `/var/run/charon.vici`).
+    /// Connect to a VICI UNIX socket.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the UNIX socket (typically `/var/run/charon.vici`)
+    ///
+    /// # Returns
+    ///
+    /// Returns a connected `Client` on success, or an `Error` if the connection fails.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rustici::Client;
+    ///
+    /// let client = Client::connect("/var/run/charon.vici")?;
+    /// ```
     pub fn connect<P: AsRef<Path>>(path: P) -> Result<Self> {
         let stream = UnixStream::connect(path)?;
         Ok(Self { stream })
     }
 
-    /// Returns the raw file descriptor (for integration with `select`/`poll`). Linux/Unix only.
+    /// Returns the raw file descriptor for integration with `select`/`poll`.
+    ///
+    /// This is useful for integrating the client into custom event loops
+    /// or for monitoring multiple file descriptors simultaneously.
+    ///
+    /// # Platform support
+    ///
+    /// Linux/Unix only.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rustici::Client;
+    ///
+    /// let client = Client::connect("/var/run/charon.vici")?;
+    /// let fd = client.as_raw_fd();
+    /// // Use fd with select(), poll(), or epoll
+    /// ```
     pub fn as_raw_fd(&self) -> i32 {
         self.stream.as_raw_fd()
     }
 
-    /// Set read/write timeouts.
+    /// Set the read timeout for socket operations.
+    ///
+    /// When set, read operations will fail with a timeout error if they
+    /// don't complete within the specified duration.
+    ///
+    /// # Arguments
+    ///
+    /// * `to` - The timeout duration, or `None` to disable timeouts (blocking mode)
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` on success, or an `Error` if setting the timeout fails.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::time::Duration;
+    /// use rustici::Client;
+    ///
+    /// let client = Client::connect("/var/run/charon.vici")?;
+    /// client.set_read_timeout(Some(Duration::from_secs(5)))?;
+    /// ```
     pub fn set_read_timeout(&self, to: Option<Duration>) -> Result<()> {
         self.stream.set_read_timeout(to).map_err(Error::Io)
     }
-    /// Set write timeout on the underlying socket.
+
+    /// Set the write timeout for socket operations.
+    ///
+    /// When set, write operations will fail with a timeout error if they
+    /// don't complete within the specified duration.
+    ///
+    /// # Arguments
+    ///
+    /// * `to` - The timeout duration, or `None` to disable timeouts (blocking mode)
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` on success, or an `Error` if setting the timeout fails.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::time::Duration;
+    /// use rustici::Client;
+    ///
+    /// let client = Client::connect("/var/run/charon.vici")?;
+    /// client.set_write_timeout(Some(Duration::from_secs(5)))?;
+    /// ```
     pub fn set_write_timeout(&self, to: Option<Duration>) -> Result<()> {
         self.stream.set_write_timeout(to).map_err(Error::Io)
     }
 
-    /// Send a *simple* RPC-style command and await its response. Any unsolicited events
-    /// received while waiting are ignored.
+    /// Send a simple RPC-style command and await its response.
+    ///
+    /// This method sends a command request and waits for the corresponding
+    /// response. Any unsolicited events received while waiting are silently
+    /// ignored.
+    ///
+    /// # Arguments
+    ///
+    /// * `command` - The VICI command name (e.g., "version", "list-sas", "initiate")
+    /// * `request` - The message payload for the command
+    ///
+    /// # Returns
+    ///
+    /// Returns the response `Message` on success. If the command is unknown
+    /// to the daemon, returns `Error::UnknownCommand`. Empty responses are
+    /// returned as empty `Message` objects.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rustici::{Client, wire::Message};
+    ///
+    /// let mut client = Client::connect("/var/run/charon.vici")?;
+    /// let response = client.call("version", &Message::new())?;
+    /// println!("Response: {}", response);
+    /// ```
     pub fn call(&mut self, command: &str, request: &Message) -> Result<Message> {
         let pkt = Packet {
             ty: PacketType::CmdRequest,
@@ -73,7 +173,29 @@ impl Client {
         }
     }
 
-    /// Register for an event name, returning Ok(()) if the daemon confirms.
+    /// Register to receive events of a specific type.
+    ///
+    /// After successful registration, the client will receive events of the
+    /// specified type which can be retrieved using `next_event()` or related methods.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The event type name (e.g., "ike-updown", "child-updown", "log")
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if registration succeeds, or an error if the event
+    /// type is unknown or registration fails.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rustici::Client;
+    ///
+    /// let mut client = Client::connect("/var/run/charon.vici")?;
+    /// client.register_event("ike-updown")?;
+    /// // Now the client will receive IKE SA up/down events
+    /// ```
     pub fn register_event(&mut self, name: &str) -> Result<()> {
         let pkt = Packet {
             ty: PacketType::EventRegister,
@@ -89,7 +211,30 @@ impl Client {
         }
     }
 
-    /// Unregister from an event name.
+    /// Unregister from receiving events of a specific type.
+    ///
+    /// After successful unregistration, the client will no longer receive
+    /// events of the specified type.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The event type name to unregister from
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if unregistration succeeds, or an error if it fails.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rustici::Client;
+    ///
+    /// let mut client = Client::connect("/var/run/charon.vici")?;
+    /// client.register_event("log")?;
+    /// // ... receive some log events ...
+    /// client.unregister_event("log")?;
+    /// // No more log events will be received
+    /// ```
     pub fn unregister_event(&mut self, name: &str) -> Result<()> {
         let pkt = Packet {
             ty: PacketType::EventUnregister,
@@ -105,9 +250,33 @@ impl Client {
         }
     }
 
-    /// Execute a *streaming* command that yields one or more EVENT packets and
-    /// finally returns a CMD_RESPONSE. For each EVENT, the provided callback is
-    /// invoked with `(event_name, event_message)`.
+    /// Execute a streaming command that yields multiple events before completing.
+    ///
+    /// Some VICI commands (like "list-sas", "list-conns") stream multiple event
+    /// packets before sending a final response. This method handles the streaming
+    /// protocol and invokes the callback for each event.
+    ///
+    /// # Arguments
+    ///
+    /// * `command` - The streaming command name
+    /// * `request` - The message payload for the command
+    /// * `on_event` - Callback invoked for each streamed event with (event_name, event_message)
+    ///
+    /// # Returns
+    ///
+    /// Returns the final response message after all events have been streamed.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rustici::{Client, wire::Message};
+    ///
+    /// let mut client = Client::connect("/var/run/charon.vici")?;
+    /// let response = client.call_streaming("list-sas", &Message::new(), |name, msg| {
+    ///     println!("Event {}: {}", name, msg);
+    /// })?;
+    /// println!("Final response: {}", response);
+    /// ```
     pub fn call_streaming<F>(
         &mut self,
         command: &str,
@@ -147,7 +316,36 @@ impl Client {
             }
         }
     }
-    /// Block until the next event message arrives. Returns the (event name, message).
+
+    /// Block until the next event message arrives.
+    ///
+    /// This method blocks indefinitely waiting for an event. You must have
+    /// registered for at least one event type using `register_event()` to
+    /// receive events.
+    ///
+    /// # Returns
+    ///
+    /// Returns a tuple of (event_name, event_message) when an event arrives.
+    ///
+    /// # Note
+    ///
+    /// This method will block forever if no events arrive. Consider using
+    /// `next_event_with_timeout()` or `try_next_event()` for non-blocking
+    /// alternatives.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use rustici::Client;
+    ///
+    /// let mut client = Client::connect("/var/run/charon.vici")?;
+    /// client.register_event("ike-updown")?;
+    ///
+    /// loop {
+    ///     let (event_name, message) = client.next_event()?;
+    ///     println!("Received event: {}", event_name);
+    /// }
+    /// ```
     pub fn next_event(&mut self) -> Result<(String, Message)> {
         loop {
             let pkt = self.recv_packet()?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -38,7 +38,10 @@ impl Client {
     /// ```no_run
     /// use rustici::Client;
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::connect("/var/run/charon.vici")?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn connect<P: AsRef<Path>>(path: P) -> Result<Self> {
         let stream = UnixStream::connect(path)?;
@@ -59,9 +62,12 @@ impl Client {
     /// ```no_run
     /// use rustici::Client;
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::connect("/var/run/charon.vici")?;
     /// let fd = client.as_raw_fd();
     /// // Use fd with select(), poll(), or epoll
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn as_raw_fd(&self) -> i32 {
         self.stream.as_raw_fd()
@@ -86,8 +92,11 @@ impl Client {
     /// use std::time::Duration;
     /// use rustici::Client;
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::connect("/var/run/charon.vici")?;
     /// client.set_read_timeout(Some(Duration::from_secs(5)))?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn set_read_timeout(&self, to: Option<Duration>) -> Result<()> {
         self.stream.set_read_timeout(to).map_err(Error::Io)
@@ -112,8 +121,11 @@ impl Client {
     /// use std::time::Duration;
     /// use rustici::Client;
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let client = Client::connect("/var/run/charon.vici")?;
     /// client.set_write_timeout(Some(Duration::from_secs(5)))?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn set_write_timeout(&self, to: Option<Duration>) -> Result<()> {
         self.stream.set_write_timeout(to).map_err(Error::Io)
@@ -141,9 +153,12 @@ impl Client {
     /// ```no_run
     /// use rustici::{Client, wire::Message};
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut client = Client::connect("/var/run/charon.vici")?;
     /// let response = client.call("version", &Message::new())?;
     /// println!("Response: {}", response);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn call(&mut self, command: &str, request: &Message) -> Result<Message> {
         let pkt = Packet {
@@ -192,9 +207,12 @@ impl Client {
     /// ```no_run
     /// use rustici::Client;
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut client = Client::connect("/var/run/charon.vici")?;
     /// client.register_event("ike-updown")?;
     /// // Now the client will receive IKE SA up/down events
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn register_event(&mut self, name: &str) -> Result<()> {
         let pkt = Packet {
@@ -229,11 +247,14 @@ impl Client {
     /// ```no_run
     /// use rustici::Client;
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut client = Client::connect("/var/run/charon.vici")?;
     /// client.register_event("log")?;
     /// // ... receive some log events ...
     /// client.unregister_event("log")?;
     /// // No more log events will be received
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn unregister_event(&mut self, name: &str) -> Result<()> {
         let pkt = Packet {
@@ -271,11 +292,14 @@ impl Client {
     /// ```no_run
     /// use rustici::{Client, wire::Message};
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut client = Client::connect("/var/run/charon.vici")?;
     /// let response = client.call_streaming("list-sas", &Message::new(), |name, msg| {
     ///     println!("Event {}: {}", name, msg);
     /// })?;
     /// println!("Final response: {}", response);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn call_streaming<F>(
         &mut self,
@@ -338,6 +362,19 @@ impl Client {
     /// ```no_run
     /// use rustici::Client;
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut client = Client::connect("/var/run/charon.vici")?;
+    /// client.register_event("ike-updown")?;
+    ///
+    /// loop {
+    ///     let (event_name, message) = client.next_event()?;
+    ///     println!("Received event: {}", event_name);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// use rustici::Client;
+    ///
     /// let mut client = Client::connect("/var/run/charon.vici")?;
     /// client.register_event("ike-updown")?;
     ///
@@ -375,6 +412,7 @@ impl Client {
     /// use std::time::Duration;
     /// use rustici::{Client, error::Error};
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut client = Client::connect("/var/run/charon.vici")?;
     /// client.set_read_timeout(Some(Duration::from_secs(1)))?;
     /// client.register_event("ike-updown")?;
@@ -389,6 +427,8 @@ impl Client {
     ///         Err(e) => eprintln!("Error: {}", e),
     ///     }
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn next_event_with_timeout(&mut self) -> Result<(String, Message)> {
         loop {
@@ -437,6 +477,7 @@ impl Client {
     /// use std::time::Duration;
     /// use rustici::{Client, error::Error};
     ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut client = Client::connect("/var/run/charon.vici")?;
     /// client.register_event("log")?;
     ///
@@ -445,6 +486,8 @@ impl Client {
     ///     Err(Error::Timeout) => println!("No event within 500ms"),
     ///     Err(e) => eprintln!("Error: {}", e),
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn try_next_event(&mut self, timeout: Duration) -> Result<(String, Message)> {
         // Save current timeout

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,8 @@ pub enum Error {
     TooLong(&'static str),
     /// UTF-8 conversion failed (when interpreting bytes as a String).
     Utf8(FromUtf8Error),
+    /// Operation timed out.
+    Timeout,
 }
 
 impl From<io::Error> for Error {
@@ -39,6 +41,7 @@ impl fmt::Display for Error {
             Error::UnknownCommand(cmd) => write!(f, "unknown command: {cmd}"),
             Error::TooLong(what) => write!(f, "value too long: {what}"),
             Error::Utf8(e) => write!(f, "utf-8 error: {e}"),
+            Error::Timeout => write!(f, "operation timed out"),
         }
     }
 }

--- a/tests/client_timeout_tests.rs
+++ b/tests/client_timeout_tests.rs
@@ -199,7 +199,7 @@ fn test_next_event_with_timeout_actually_times_out() {
 
     // Try to get an event - should timeout
     let start = Instant::now();
-    let result = client.next_event_with_timeout();
+    let result = client.next_event();
     let elapsed = start.elapsed();
 
     // Verify it timed out
@@ -277,7 +277,7 @@ fn test_timeout_methods_receive_events_when_available() {
         .expect("Failed to set timeout");
 
     let start = Instant::now();
-    let result = client.next_event_with_timeout();
+    let result = client.next_event();
     let elapsed = start.elapsed();
 
     // Should receive event before timeout

--- a/tests/client_timeout_tests.rs
+++ b/tests/client_timeout_tests.rs
@@ -1,0 +1,469 @@
+//! Integration tests for timeout functionality in the VICI client
+//!
+//! Place this file in: tests/client_timeout_tests.rs
+//! Run with: cargo test
+
+use rustici::{error::Error, Client};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+// Mock server implementation for testing
+mod mock_vici_server {
+    use std::io::{Read, Write};
+    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    pub struct MockViciServer {
+        listener: UnixListener,
+        running: Arc<AtomicBool>,
+        socket_path: String,
+    }
+
+    impl MockViciServer {
+        pub fn new(socket_path: &str) -> std::io::Result<Self> {
+            // Remove existing socket if it exists
+            let _ = std::fs::remove_file(socket_path);
+
+            let listener = UnixListener::bind(socket_path)?;
+            listener.set_nonblocking(true)?;
+
+            Ok(Self {
+                listener,
+                running: Arc::new(AtomicBool::new(true)),
+                socket_path: socket_path.to_string(),
+            })
+        }
+
+        /// Start server that sends events at specified intervals
+        pub fn start_with_events(self, event_interval: Option<Duration>) -> MockServerHandle {
+            let running = self.running.clone();
+            let socket_path = self.socket_path.clone();
+
+            let handle = thread::spawn(move || {
+                while running.load(Ordering::Relaxed) {
+                    match self.listener.accept() {
+                        Ok((mut stream, _)) => {
+                            let running = running.clone();
+                            thread::spawn(move || {
+                                handle_client(&mut stream, &running, event_interval);
+                            });
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+
+            MockServerHandle {
+                running: self.running,
+                handle: Some(handle),
+                socket_path,
+            }
+        }
+
+        /// Start server that never sends events (for timeout testing)
+        pub fn start_silent(self) -> MockServerHandle {
+            self.start_with_events(None)
+        }
+    }
+
+    fn handle_client(
+        stream: &mut UnixStream,
+        running: &Arc<AtomicBool>,
+        event_interval: Option<Duration>,
+    ) {
+        let _ = stream.set_nonblocking(true);
+        let mut last_event = Instant::now();
+
+        while running.load(Ordering::Relaxed) {
+            // Read any incoming packets (event registrations, etc.)
+            let mut buf = [0u8; 1024];
+            match stream.read(&mut buf) {
+                Ok(0) => break, // Connection closed
+                Ok(n) => {
+                    // Parse packet to see if it's an event registration
+                    if n >= 5 && buf[4] == 3 {
+                        // EventRegister
+                        // Send EventConfirm
+                        let confirm = vec![0, 0, 0, 1, 5]; // Length=1, Type=EventConfirm
+                        let _ = stream.write_all(&confirm);
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    // No data available
+                }
+                Err(_) => break,
+            }
+
+            // Send periodic events if configured
+            if let Some(interval) = event_interval {
+                if last_event.elapsed() >= interval {
+                    send_test_event(stream);
+                    last_event = Instant::now();
+                }
+            }
+
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn send_test_event(stream: &mut UnixStream) {
+        // Create a simple test event
+        // PacketType::Event = 7
+        let event_name = "test-event";
+        let event_data = create_simple_message();
+
+        let mut packet = vec![7]; // Event type
+        packet.push(event_name.len() as u8);
+        packet.extend_from_slice(event_name.as_bytes());
+        packet.extend_from_slice(&event_data);
+
+        let len = packet.len() as u32;
+        let mut frame = len.to_be_bytes().to_vec();
+        frame.extend_from_slice(&packet);
+
+        let _ = stream.write_all(&frame);
+    }
+
+    fn create_simple_message() -> Vec<u8> {
+        // Create a simple message with one key-value pair
+        let mut msg = vec![];
+        msg.push(3); // KEY_VALUE
+        let key = "status";
+        msg.push(key.len() as u8);
+        msg.extend_from_slice(key.as_bytes());
+        let value = "test";
+        msg.extend_from_slice(&(value.len() as u16).to_be_bytes());
+        msg.extend_from_slice(value.as_bytes());
+        msg
+    }
+
+    pub struct MockServerHandle {
+        running: Arc<AtomicBool>,
+        #[allow(dead_code)]
+        handle: Option<thread::JoinHandle<()>>,
+        socket_path: String,
+    }
+
+    impl MockServerHandle {
+        #[allow(dead_code)]
+        pub fn stop(mut self) {
+            self.running.store(false, Ordering::Relaxed);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
+    impl Drop for MockServerHandle {
+        fn drop(&mut self) {
+            self.running.store(false, Ordering::Relaxed);
+            let _ = std::fs::remove_file(&self.socket_path);
+        }
+    }
+}
+
+use mock_vici_server::MockViciServer;
+
+/// Test that next_event_with_timeout times out when no events arrive
+#[test]
+fn test_next_event_with_timeout_actually_times_out() {
+    let socket_path = "/tmp/test_vici_timeout.sock";
+
+    // Start a mock server that never sends events
+    let server = MockViciServer::new(socket_path).expect("Failed to create mock server");
+    let _server_handle = server.start_silent();
+
+    // Give server time to start
+    thread::sleep(Duration::from_millis(100));
+
+    // Connect client
+    let mut client = Client::connect(socket_path).expect("Failed to connect");
+
+    // Set a short read timeout
+    client
+        .set_read_timeout(Some(Duration::from_millis(100)))
+        .expect("Failed to set timeout");
+
+    // Register for events
+    client
+        .register_event("test-event")
+        .expect("Failed to register event");
+
+    // Try to get an event - should timeout
+    let start = Instant::now();
+    let result = client.next_event_with_timeout();
+    let elapsed = start.elapsed();
+
+    // Verify it timed out
+    assert!(matches!(result, Err(Error::Timeout)));
+
+    // Verify it actually waited approximately the timeout duration
+    assert!(elapsed >= Duration::from_millis(90)); // Allow some margin
+    assert!(elapsed < Duration::from_millis(200)); // But not too long
+}
+
+/// Test that try_next_event respects the specified timeout
+#[test]
+fn test_try_next_event_with_custom_timeout() {
+    let socket_path = "/tmp/test_vici_try_timeout.sock";
+
+    // Start a mock server that never sends events
+    let server = MockViciServer::new(socket_path).expect("Failed to create mock server");
+    let _server_handle = server.start_silent();
+
+    // Give server time to start
+    thread::sleep(Duration::from_millis(100));
+
+    // Connect client
+    let mut client = Client::connect(socket_path).expect("Failed to connect");
+
+    // Register for events
+    client
+        .register_event("test-event")
+        .expect("Failed to register event");
+
+    // Test with different timeout values
+    let timeouts = vec![
+        Duration::from_millis(50),
+        Duration::from_millis(100),
+        Duration::from_millis(200),
+    ];
+
+    for timeout in timeouts {
+        let start = Instant::now();
+        let result = client.try_next_event(timeout);
+        let elapsed = start.elapsed();
+
+        // Should timeout
+        assert!(matches!(result, Err(Error::Timeout)));
+
+        // Should respect the timeout duration (with some margin for test stability)
+        assert!(elapsed >= timeout.saturating_sub(Duration::from_millis(20)));
+        assert!(elapsed < timeout + Duration::from_millis(50));
+    }
+}
+
+/// Test that events are received when they arrive before timeout
+#[test]
+fn test_timeout_methods_receive_events_when_available() {
+    let socket_path = "/tmp/test_vici_events_received.sock";
+
+    // Start a mock server that sends events every 50ms
+    let server = MockViciServer::new(socket_path).expect("Failed to create mock server");
+    let _server_handle = server.start_with_events(Some(Duration::from_millis(50)));
+
+    // Give server time to start
+    thread::sleep(Duration::from_millis(100));
+
+    // Connect client
+    let mut client = Client::connect(socket_path).expect("Failed to connect");
+
+    // Register for events
+    client
+        .register_event("test-event")
+        .expect("Failed to register event");
+
+    // Test with next_event_with_timeout
+    client
+        .set_read_timeout(Some(Duration::from_millis(200)))
+        .expect("Failed to set timeout");
+
+    let start = Instant::now();
+    let result = client.next_event_with_timeout();
+    let elapsed = start.elapsed();
+
+    // Should receive event before timeout
+    assert!(result.is_ok());
+    let (event_name, _msg) = result.unwrap();
+    assert_eq!(event_name, "test-event");
+    assert!(elapsed < Duration::from_millis(100)); // Should be fast
+
+    // Test with try_next_event
+    let start = Instant::now();
+    let result = client.try_next_event(Duration::from_millis(200));
+    let elapsed = start.elapsed();
+
+    // Should receive event before timeout
+    assert!(result.is_ok());
+    let (event_name, _msg) = result.unwrap();
+    assert_eq!(event_name, "test-event");
+    assert!(elapsed < Duration::from_millis(100)); // Should be fast
+}
+
+/// Test graceful shutdown pattern using timeout
+#[test]
+fn test_graceful_shutdown_with_timeout() {
+    let socket_path = "/tmp/test_vici_shutdown.sock";
+
+    // Start a mock server that rarely sends events
+    let server = MockViciServer::new(socket_path).expect("Failed to create mock server");
+    let _server_handle = server.start_with_events(Some(Duration::from_secs(10)));
+
+    // Give server time to start
+    thread::sleep(Duration::from_millis(100));
+
+    // Connect client
+    let client = Arc::new(Mutex::new(
+        Client::connect(socket_path).expect("Failed to connect"),
+    ));
+
+    // Register for events
+    client
+        .lock()
+        .unwrap()
+        .register_event("test-event")
+        .expect("Failed to register event");
+
+    // Simulate event listener with graceful shutdown
+    let running = Arc::new(AtomicBool::new(true));
+    let running_clone = running.clone();
+    let client_clone = client.clone();
+
+    let listener_thread = thread::spawn(move || {
+        let mut event_count = 0;
+
+        while running_clone.load(Ordering::Relaxed) {
+            // Use try_next_event with short timeout for responsive shutdown
+            let result = client_clone
+                .lock()
+                .unwrap()
+                .try_next_event(Duration::from_millis(100));
+
+            match result {
+                Ok((_event_name, _msg)) => {
+                    event_count += 1;
+                    // Process event...
+                }
+                Err(Error::Timeout) => {
+                    // Timeout is expected and allows checking shutdown flag
+                    continue;
+                }
+                Err(e) => {
+                    eprintln!("Error receiving event: {:?}", e);
+                    break;
+                }
+            }
+        }
+
+        event_count
+    });
+
+    // Let it run briefly
+    thread::sleep(Duration::from_millis(300));
+
+    // Signal shutdown
+    let shutdown_start = Instant::now();
+    running.store(false, Ordering::Relaxed);
+
+    // Wait for thread to finish
+    let event_count = listener_thread.join().expect("Failed to join thread");
+    let shutdown_duration = shutdown_start.elapsed();
+
+    // Verify graceful shutdown
+    assert!(
+        shutdown_duration < Duration::from_millis(200),
+        "Shutdown took too long: {:?}",
+        shutdown_duration
+    );
+
+    // Event count doesn't matter, just that we shut down gracefully
+    println!("Processed {} events before shutdown", event_count);
+}
+
+/// Integration test simulating the actual use case from the issue
+#[test]
+fn test_event_listener_loop_with_stop_signal() {
+    let socket_path = "/tmp/test_vici_integration.sock";
+
+    // Start mock server
+    let server = MockViciServer::new(socket_path).expect("Failed to create mock server");
+    let _server_handle = server.start_with_events(Some(Duration::from_secs(10)));
+
+    thread::sleep(Duration::from_millis(100));
+
+    // This simulates the actual event listener pattern from the issue
+    struct EventListener {
+        running: Arc<AtomicBool>,
+        client: Arc<Mutex<Option<Client>>>,
+    }
+
+    impl EventListener {
+        fn new(socket_path: &str) -> Self {
+            let mut client = Client::connect(socket_path).expect("Failed to connect");
+            client
+                .register_event("ike-updown")
+                .expect("Failed to register");
+
+            Self {
+                running: Arc::new(AtomicBool::new(true)),
+                client: Arc::new(Mutex::new(Some(client))),
+            }
+        }
+
+        fn start(&self) -> thread::JoinHandle<()> {
+            let running = self.running.clone();
+            let client = self.client.clone();
+
+            thread::spawn(move || {
+                while running.load(Ordering::Relaxed) {
+                    let mut client_guard = client.lock().unwrap();
+
+                    if let Some(ref mut c) = *client_guard {
+                        // THIS IS THE FIX: Use try_next_event instead of next_event
+                        match c.try_next_event(Duration::from_millis(100)) {
+                            Ok((event_name, message)) => {
+                                println!("Event: {} - {:?}", event_name, message);
+                            }
+                            Err(Error::Timeout) => {
+                                // Check running flag on timeout - allows graceful shutdown
+                                continue;
+                            }
+                            Err(e) => {
+                                println!("Error: {:?}", e);
+                                // In real code, might try to reconnect here
+                                thread::sleep(Duration::from_millis(500));
+                            }
+                        }
+                    } else {
+                        // Client disconnected, try to reconnect
+                        thread::sleep(Duration::from_millis(500));
+                    }
+                }
+            })
+        }
+
+        fn stop(&self) {
+            self.running.store(false, Ordering::Relaxed);
+        }
+    }
+
+    // Test the pattern
+    let listener = EventListener::new(socket_path);
+    let handle = listener.start();
+
+    // Let it run
+    thread::sleep(Duration::from_millis(300));
+
+    // Stop it
+    let stop_start = Instant::now();
+    listener.stop();
+
+    // Wait for thread
+    handle.join().expect("Failed to join listener thread");
+    let stop_duration = stop_start.elapsed();
+
+    // Verify it stopped quickly (within timeout + small margin)
+    assert!(
+        stop_duration < Duration::from_millis(200),
+        "Stop took too long: {:?}",
+        stop_duration
+    );
+}


### PR DESCRIPTION
## Description

This PR enhances the client library by introducing timeout support, improving documentation, and providing improved error handling.

### Changes

- Timeout Handling
 - Added Timeout variant to Error enum with Display implementation.
- Introduced new client methods: next_event_with_timeout and try_next_event.
- Implemented integration tests with a mock VICI server to verify timeout behavior.

### Documentation
- Expanded Rustdoc with clarified API behavior and examples.
- Added main() wrappers with Result return types in examples for easier testing and usage.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Documentation update
- [X] Test coverage improvement

## Changes Made

- List the main changes made in this PR
- Be specific about what was added, modified, or removed

## Testing

- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have tested this manually

## Documentation

- [X] I have updated the documentation accordingly
- [X] I have added inline code comments where necessary

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have run `cargo fmt` and `cargo clippy`
- [X] Any dependent changes have been merged and published

## Related Issues

Fixes #6 
